### PR TITLE
Fix furigana display issues

### DIFF
--- a/Talkyo/FuriganaToken.swift
+++ b/Talkyo/FuriganaToken.swift
@@ -21,18 +21,18 @@ struct FuriganaToken: Equatable {
     /// Returns true if:
     /// - There is a reading available
     /// - The reading differs from the base text
-    /// - The text contains kanji or katakana characters
+    /// - The text contains kanji characters (not katakana)
     var needsFurigana: Bool {
         guard let reading = reading else { return false }
-        return reading != text && containsKanjiOrKatakana
+        return reading != text && containsKanji
     }
     
     // MARK: - Private Properties
     
-    /// Checks if the text contains any kanji or katakana characters
-    private var containsKanjiOrKatakana: Bool {
+    /// Checks if the text contains any kanji characters
+    private var containsKanji: Bool {
         text.contains { character in
-            isKanji(character) || isKatakana(character)
+            isKanji(character)
         }
     }
     


### PR DESCRIPTION
Fixes the furigana alignment and unnecessary character issues reported in #8.

## Changes
- Split mixed tokens (kanji+hiragana) by character type for proper alignment
- Remove hiragana suffixes from readings before assigning to kanji
- Only show furigana for kanji characters, not katakana
- Fix cases like "新しい" showing "あたらしい" above "新" (now shows "あたら")
- Remove furigana from katakana words like "パソコン"

Generated with [Claude Code](https://claude.ai/code)