### PR TITLE
Fix settings screen UI with original segmented picker design

### DIFF
--- a/Talkyo/ContentView.swift
+++ b/Talkyo/ContentView.swift
@@ -45,69 +45,48 @@ struct ContentView: View {
     @State private var isRecording = false
     @State private var selectedMode = SpeechRecognitionMode.onDevice
     @State private var transcriptionMode = TranscriptionMode.standard
+    @State private var showingSettings = false
     
     var body: some View {
-        VStack(spacing: 20) {
-            VStack(spacing: 16) {
-                transcriptionModeSelector
-                recognitionModeSelector
+        NavigationView {
+            VStack(spacing: 20) {
+                TranscriptionDisplay(
+                    transcribedText: transcriptionService.transcribedText,
+                    furiganaTokens: transcriptionService.furiganaTokens,
+                    processingTime: transcriptionService.transcriptionTime,
+                    isLiveMode: transcriptionMode == .live,
+                    isRecording: isRecording
+                )
+                .padding(.top, 20)
+                
+                Spacer()
+                
+                controlButtons
+                    .padding(.bottom, 50)
             }
-            .padding(.top, 20)
-            
-            TranscriptionDisplay(
-                transcribedText: transcriptionService.transcribedText,
-                furiganaTokens: transcriptionService.furiganaTokens,
-                processingTime: transcriptionService.transcriptionTime,
-                isLiveMode: transcriptionMode == .live,
-                isRecording: isRecording
-            )
-            
-            Spacer()
-            
-            controlButtons
-                .padding(.bottom, 50)
+            .navigationTitle("Talkyo")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        showingSettings = true
+                    }) {
+                        Image(systemName: "gearshape.fill")
+                            .font(.title2)
+                    }
+                }
+            }
+            .sheet(isPresented: $showingSettings) {
+                SettingsView(
+                    selectedMode: $selectedMode,
+                    transcriptionMode: $transcriptionMode,
+                    transcriptionService: transcriptionService
+                )
+            }
         }
     }
     
     // MARK: - View Components
-    
-    private var transcriptionModeSelector: some View {
-        VStack(spacing: 10) {
-            Text("Transcription Mode")
-                .font(.caption)
-                .foregroundColor(.secondary)
-            
-            Picker("Mode", selection: $transcriptionMode) {
-                ForEach(TranscriptionMode.allCases, id: \.self) { mode in
-                    Text(mode.rawValue).tag(mode)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal)
-            .onChange(of: transcriptionMode) { _, newValue in
-                transcriptionService.setTranscriptionMode(newValue)
-            }
-        }
-    }
-    
-    private var recognitionModeSelector: some View {
-        VStack(spacing: 10) {
-            Text("Recognition Mode")
-                .font(.caption)
-                .foregroundColor(.secondary)
-            
-            Picker("Mode", selection: $selectedMode) {
-                ForEach(SpeechRecognitionMode.allCases, id: \.self) { mode in
-                    Text(mode.rawValue).tag(mode)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal)
-            .onChange(of: selectedMode) { _, newValue in
-                transcriptionService.setRecognitionMode(newValue)
-            }
-        }
-    }
     
     private var controlButtons: some View {
         VStack(spacing: 16) {

--- a/Talkyo/SettingsView.swift
+++ b/Talkyo/SettingsView.swift
@@ -1,0 +1,74 @@
+//
+//  SettingsView.swift
+//  Talkyo
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @Binding var selectedMode: SpeechRecognitionMode
+    @Binding var transcriptionMode: TranscriptionMode
+    @ObservedObject var transcriptionService: TranscriptionService
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 30) {
+                VStack(spacing: 16) {
+                    transcriptionModeSelector
+                    recognitionModeSelector
+                }
+                .padding(.top, 40)
+                
+                Spacer()
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+    
+    private var transcriptionModeSelector: some View {
+        VStack(spacing: 10) {
+            Text("Transcription Mode")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            
+            Picker("Mode", selection: $transcriptionMode) {
+                ForEach(TranscriptionMode.allCases, id: \.self) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+            .onChange(of: transcriptionMode) { _, newValue in
+                transcriptionService.setTranscriptionMode(newValue)
+            }
+        }
+    }
+    
+    private var recognitionModeSelector: some View {
+        VStack(spacing: 10) {
+            Text("Recognition Mode")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            
+            Picker("Mode", selection: $selectedMode) {
+                ForEach(SpeechRecognitionMode.allCases, id: \.self) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+            .onChange(of: selectedMode) { _, newValue in
+                transcriptionService.setRecognitionMode(newValue)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #5

Fixes the settings screen UI issue where toggle labels were truncated and unreadable. Restored the original clean segmented picker design while keeping toggles in the dedicated settings screen.

## Changes
- Created SettingsView.swift using original segmented picker components
- Updated ContentView.swift to remove toggles and add gear icon navigation
- Preserved all existing functionality and state bindings
- Fixed truncated button labels that were impossible to read

## Result
- Settings show readable "Standard/Live" and "On-Device/Server/Hybrid" labels
- Clean native iOS segmented picker UI
- Main screen focused on core transcription functionality

🤖 Generated with [Claude Code](https://claude.ai/code)