### PR TITLE
Fix GitHub Actions build workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -34,8 +34,9 @@ jobs:
 
       - name: Resolve Swift Package Dependencies
         run: |
-          cd Talkyo.xcodeproj
-          xcodebuild -resolvePackageDependencies -scheme Talkyo
+          xcodebuild -resolvePackageDependencies \
+            -project Talkyo.xcodeproj \
+            -scheme Talkyo
         working-directory: .
 
       - name: Build for iOS Simulator


### PR DESCRIPTION
- Remove incorrect 'cd Talkyo.xcodeproj' command
- Use proper xcodebuild syntax with -project flag
- Fixes exit code 66 error in PR builds

The workflow was trying to cd into a project file instead of using it as an argument.