### PR TITLE
Remove WhisperKit and other unused dependencies

### DIFF
--- a/Talkyo.xcodeproj/project.pbxproj
+++ b/Talkyo.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		521977052E4111F5007FD1C8 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 521977042E4111F5007FD1C8 /* WhisperKit */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,7 +26,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				521977052E4111F5007FD1C8 /* WhisperKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -70,7 +68,6 @@
 			);
 			name = Talkyo;
 			packageProductDependencies = (
-				521977042E4111F5007FD1C8 /* WhisperKit */,
 			);
 			productName = Talkyo;
 			productReference = 521976EF2E3E6373007FD1C8 /* Talkyo.app */;
@@ -101,7 +98,6 @@
 			mainGroup = 521976E62E3E6373007FD1C8;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				521977032E4111F5007FD1C8 /* XCRemoteSwiftPackageReference "WhisperKit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 521976F02E3E6373007FD1C8 /* Products */;
@@ -341,22 +337,9 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		521977032E4111F5007FD1C8 /* XCRemoteSwiftPackageReference "WhisperKit" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/argmaxinc/WhisperKit";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		521977042E4111F5007FD1C8 /* WhisperKit */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 521977032E4111F5007FD1C8 /* XCRemoteSwiftPackageReference "WhisperKit" */;
-			productName = WhisperKit;
-		};
 /* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 521976E72E3E6373007FD1C8 /* Project object */;

--- a/Talkyo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Talkyo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,51 +1,6 @@
 {
-  "originHash" : "e843284a09b9d7fb8d0032fe1a3fd1fbd38f28ea54d42a39ccbe396af16d225d",
+  "originHash" : "",
   "pins" : [
-    {
-      "identity" : "jinja",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/johnmai-dev/Jinja",
-      "state" : {
-        "revision" : "fc1233dea1142897d474bda2f1f9a6c3fe7acab6",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
-        "version" : "1.6.1"
-      }
-    },
-    {
-      "identity" : "swift-collections",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
-      "state" : {
-        "revision" : "8c0c0a8b49e080e54e5e328cc552821ff07cd341",
-        "version" : "1.2.1"
-      }
-    },
-    {
-      "identity" : "swift-transformers",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers.git",
-      "state" : {
-        "revision" : "8a83416cc00ab07a5de9991e6ad817a9b8588d20",
-        "version" : "0.1.15"
-      }
-    },
-    {
-      "identity" : "whisperkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/argmaxinc/WhisperKit",
-      "state" : {
-        "branch" : "main",
-        "revision" : "0a064c3ba8b424887ce691c2f6c85ddffde0ce89"
-      }
-    }
   ],
   "version" : 3
 }


### PR DESCRIPTION
Removed WhisperKit from Xcode project configuration and cleaned up Package.resolved removing all unused dependencies.

Verified no third-party dependencies are actually imported in code - only system frameworks are used.

Closes #21

Generated with [Claude Code](https://claude.ai/code)